### PR TITLE
Add MatchEndCause to change Stats saving behavior

### DIFF
--- a/src/main/java/net/ninebolt/onevsone/OneVsOne.java
+++ b/src/main/java/net/ninebolt/onevsone/OneVsOne.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.UnsupportedEncodingException;
 
+import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.serialization.ConfigurationSerialization;
@@ -18,8 +19,10 @@ import net.ninebolt.onevsone.command.GameGUICommand;
 import net.ninebolt.onevsone.command.RootCommand;
 import net.ninebolt.onevsone.event.CacheUniqueIdListener;
 import net.ninebolt.onevsone.event.CreateStatsListener;
+import net.ninebolt.onevsone.event.MatchEndEvent;
 import net.ninebolt.onevsone.event.MatchListener;
 import net.ninebolt.onevsone.match.Match;
+import net.ninebolt.onevsone.match.MatchEndCause;
 import net.ninebolt.onevsone.match.MatchManager;
 import net.ninebolt.onevsone.match.MatchSelector;
 import net.ninebolt.onevsone.stats.Stats;
@@ -96,6 +99,8 @@ public class OneVsOne extends JavaPlugin {
 		}
 		// すべてのマッチを安全に無効化
 		for(Match match : matchManager.getMatches()) {
+			MatchEndEvent event = new MatchEndEvent(match, MatchEndCause.INTERRUPTED);
+			Bukkit.getPluginManager().callEvent(event);
 			match.stop();
 		}
 	}

--- a/src/main/java/net/ninebolt/onevsone/event/MatchEndEvent.java
+++ b/src/main/java/net/ninebolt/onevsone/event/MatchEndEvent.java
@@ -4,13 +4,15 @@ import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
 import net.ninebolt.onevsone.match.Match;
+import net.ninebolt.onevsone.match.MatchEndCause;
 
 public class MatchEndEvent extends Event {
 
 	private Match match;
+	private MatchEndCause cause;
 	private static final HandlerList HANDLERS = new HandlerList();
 
-	public MatchEndEvent(Match match) {
+	public MatchEndEvent(Match match, MatchEndCause cause) {
 		this.match = match;
 	}
 
@@ -27,4 +29,7 @@ public class MatchEndEvent extends Event {
 		return match;
 	}
 
+	public MatchEndCause getCause() {
+		return cause;
+	}
 }

--- a/src/main/java/net/ninebolt/onevsone/event/MatchListener.java
+++ b/src/main/java/net/ninebolt/onevsone/event/MatchListener.java
@@ -14,6 +14,7 @@ import org.bukkit.event.player.PlayerQuitEvent;
 
 import net.ninebolt.onevsone.OneVsOne;
 import net.ninebolt.onevsone.match.Match;
+import net.ninebolt.onevsone.match.MatchEndCause;
 import net.ninebolt.onevsone.match.MatchManager;
 import net.ninebolt.onevsone.match.MatchState;
 import net.ninebolt.onevsone.stats.Stats;
@@ -133,16 +134,20 @@ public class MatchListener implements Listener {
 	public void onMatchEnd(MatchEndEvent event) {
 		event.getMatch().sendMessage("マッチ終了！");
 
-		// save stats
-		for(Player player : event.getMatch().getPlayers()) {
-			if(player != null) {
-				StatsManager manager = OneVsOne.getStatsManager();
-				Stats stats = manager.getStats(player.getUniqueId().toString());
-				stats.addKills(event.getMatch().getMatchData().getKill(player));
-				stats.addDeaths(event.getMatch().getMatchData().getDeath(player));
-				// stats.addWins();
-				// stats.addDefeats();
-				manager.save(player.getUniqueId().toString(), stats);
+		if(event.getCause() == MatchEndCause.INTERRUPTED) {
+			// statsを保存しない
+		} else {
+			// save stats
+			for(Player player : event.getMatch().getPlayers()) {
+				if(player != null) {
+					StatsManager manager = OneVsOne.getStatsManager();
+					Stats stats = manager.getStats(player.getUniqueId().toString());
+					stats.addKills(event.getMatch().getMatchData().getKill(player));
+					stats.addDeaths(event.getMatch().getMatchData().getDeath(player));
+					// stats.addWins();
+					// stats.addDefeats();
+					manager.save(player.getUniqueId().toString(), stats);
+				}
 			}
 		}
 	}

--- a/src/main/java/net/ninebolt/onevsone/match/Match.java
+++ b/src/main/java/net/ninebolt/onevsone/match/Match.java
@@ -234,9 +234,6 @@ public class Match {
 	 */
 	public void stop() {
 		// call event
-		MatchEndEvent event = new MatchEndEvent(this);
-		Bukkit.getPluginManager().callEvent(event);
-
 		for(Player player : players) {
 			if(player != null) {
 				removePlayer(player);
@@ -252,6 +249,8 @@ public class Match {
 	 */
 	public void startNextRound() {
 		if(getMatchData().getRound() > MAX_ROUND) {
+			MatchEndEvent event = new MatchEndEvent(this, MatchEndCause.FINISHED);
+			Bukkit.getPluginManager().callEvent(event);
 			stop();
 			return;
 		}

--- a/src/main/java/net/ninebolt/onevsone/match/MatchEndCause.java
+++ b/src/main/java/net/ninebolt/onevsone/match/MatchEndCause.java
@@ -1,0 +1,7 @@
+package net.ninebolt.onevsone.match;
+
+public enum MatchEndCause {
+	FINISHED,
+	PLAYER_LEFT,
+	INTERRUPTED,
+}


### PR DESCRIPTION
MatchEndEventに、MatchEndCauseを追加します。

この変更により、Matchの終了時の原因によって処理を分けることができるようになります。

MatchEndCauseがとりうる値
- FINISHED: 正常にMatchが終了した
- PLAYER_LEFT: プレイヤーが試合中に切断した
- INTERRUPTED: サーバの終了やリロードで強制的にMatchが終了した